### PR TITLE
Detect RPI from Mac on en0

### DIFF
--- a/cloudlets/device/default/src/main/groovy/io/rhiot/cloudlets/device/DeviceCloudlet.groovy
+++ b/cloudlets/device/default/src/main/groovy/io/rhiot/cloudlets/device/DeviceCloudlet.groovy
@@ -16,7 +16,7 @@
  */
 package io.rhiot.cloudlets.device
 
-import io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle
+import io.rhiot.cloudlets.device.verticles.LeshanServerVerticle
 import io.rhiot.cloudlets.device.verticles.DeviceRestApiVerticle
 import io.vertx.groovy.core.Vertx
 
@@ -40,7 +40,7 @@ class DeviceCloudlet {
     // Lifecycle operations
 
     DeviceCloudlet start() {
-        vertx.deployVerticle("groovy:${LeshanServerVeritcle.class.name}")
+        vertx.deployVerticle("groovy:${LeshanServerVerticle.class.name}")
         vertx.deployVerticle("groovy:${DeviceRestApiVerticle.class.name}")
         return this
     }

--- a/cloudlets/device/default/src/main/groovy/io/rhiot/cloudlets/device/verticles/DeviceRestApiVerticle.groovy
+++ b/cloudlets/device/default/src/main/groovy/io/rhiot/cloudlets/device/verticles/DeviceRestApiVerticle.groovy
@@ -20,14 +20,14 @@ import io.rhiot.cloudlets.device.DeviceCloudlet
 import io.rhiot.vertx.web.BaseRestApiVerticle
 
 import static com.github.camellabs.iot.cloudlet.device.leshan.DeviceDetail.allDeviceDetails
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICES_DEREGISTER
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICES_DISCONNECTED
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICES_LIST
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICE_CREATE_VIRTUAL
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICE_DEREGISTER
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICE_DETAILS
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICE_GET
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.CHANNEL_DEVICE_HEARTBEAT_SEND
+import static LeshanServerVerticle.CHANNEL_DEVICES_DEREGISTER
+import static LeshanServerVerticle.CHANNEL_DEVICES_DISCONNECTED
+import static LeshanServerVerticle.CHANNEL_DEVICES_LIST
+import static LeshanServerVerticle.CHANNEL_DEVICE_CREATE_VIRTUAL
+import static LeshanServerVerticle.CHANNEL_DEVICE_DEREGISTER
+import static LeshanServerVerticle.CHANNEL_DEVICE_DETAILS
+import static LeshanServerVerticle.CHANNEL_DEVICE_GET
+import static LeshanServerVerticle.CHANNEL_DEVICE_HEARTBEAT_SEND
 
 class DeviceRestApiVerticle extends BaseRestApiVerticle {
 

--- a/cloudlets/device/default/src/main/groovy/io/rhiot/cloudlets/device/verticles/LeshanServerVerticle.groovy
+++ b/cloudlets/device/default/src/main/groovy/io/rhiot/cloudlets/device/verticles/LeshanServerVerticle.groovy
@@ -58,7 +58,7 @@ import static java.util.concurrent.TimeUnit.MINUTES
 import static org.eclipse.leshan.ResponseCode.CONTENT
 import static org.infinispan.configuration.cache.CacheMode.INVALIDATION_ASYNC
 
-class LeshanServerVeritcle extends GroovyVerticle {
+class LeshanServerVerticle extends GroovyVerticle {
 
     // Constants
 
@@ -94,7 +94,7 @@ class LeshanServerVeritcle extends GroovyVerticle {
 
     final def disconnectionPeriod = longProperty('disconnectionPeriod', DEFAULT_DISCONNECTION_PERIOD)
 
-    LeshanServerVeritcle() {
+    LeshanServerVerticle() {
         def cacheManager = new DefaultCacheManager(new GlobalConfigurationBuilder().transport().defaultTransport().build())
         Configuration builder = new ConfigurationBuilder().clustering().cacheMode(INVALIDATION_ASYNC).build();
         cacheManager.defineConfiguration("clients", builder);

--- a/cloudlets/device/default/src/test/groovy/io/rhiot/cloudlets/device/DeviceCloudletTest.groovy
+++ b/cloudlets/device/default/src/test/groovy/io/rhiot/cloudlets/device/DeviceCloudletTest.groovy
@@ -24,7 +24,7 @@ import org.springframework.web.client.RestTemplate
 
 import static com.github.camellabs.iot.cloudlet.device.client.LeshanClientTemplate.createGenericLeshanClientTemplate
 import static com.google.common.truth.Truth.assertThat
-import static io.rhiot.cloudlets.device.verticles.LeshanServerVeritcle.UNKNOWN_DISCONNECTED
+import static io.rhiot.cloudlets.device.verticles.LeshanServerVerticle.UNKNOWN_DISCONNECTED
 import static io.rhiot.utils.Networks.findAvailableTcpPort
 import static io.rhiot.utils.Properties.setIntProperty
 import static io.rhiot.utils.Uuids.uuid

--- a/iot/deployer/src/main/groovy/com/github/camellabs/iot/deployer/SimplePortScanningDeviceDetector.groovy
+++ b/iot/deployer/src/main/groovy/com/github/camellabs/iot/deployer/SimplePortScanningDeviceDetector.groovy
@@ -56,7 +56,8 @@ class SimplePortScanningDeviceDetector implements DeviceDetector {
 
     List<Inet4Address> detectReachableAddresses() {
         List<NetworkInterface> networkInterfaces = list(getNetworkInterfaces()).parallelStream().
-                filter { iface -> iface.getDisplayName().startsWith("wlan") || iface.getDisplayName().startsWith("eth") }.
+                filter { iface -> iface.getDisplayName().startsWith("wlan") || iface.getDisplayName().startsWith("eth")  || 
+                        iface.getDisplayName().startsWith("en") }.
                 collect(toList());
 
         if (networkInterfaces.isEmpty()) {


### PR DESCRIPTION
RpiDetectorTest doesn’t run with a connected PI on the wifi when the laptop uses en0, if this is something I can configure differently please advise.
RpiDetectorTest executes and passes after this change.

**- org.junit.AssumptionViolatedException: The test should be executed only when the proper network interfaces are available.**

Network setup shows the following;
**networksetup -listallhardwareports**
SNIP
Hardware Port: Wi-Fi
Device: **en0**
