### PR TITLE
Scan OSX network interfaces

### DIFF
--- a/iot/deployer/src/main/groovy/io/rhiot/deployer/SimplePortScanningDeviceDetector.groovy
+++ b/iot/deployer/src/main/groovy/io/rhiot/deployer/SimplePortScanningDeviceDetector.groovy
@@ -56,7 +56,8 @@ class SimplePortScanningDeviceDetector implements DeviceDetector {
 
     List<Inet4Address> detectReachableAddresses() {
         List<NetworkInterface> networkInterfaces = list(getNetworkInterfaces()).parallelStream().
-                filter { iface -> iface.getDisplayName().startsWith("wlan") || iface.getDisplayName().startsWith("eth") }.
+                filter { iface -> iface.getDisplayName().startsWith("wlan") || iface.getDisplayName().startsWith("eth") ||
+                         iface.getDisplayName().startsWith("en")}.
                 collect(toList());
 
         if (networkInterfaces.isEmpty()) {


### PR DESCRIPTION
I've tested this change on my system and RpiDetectorTest now passes with a Pi on the network, however there's possibility of other cases.
I think this will cover most bases and someone using fw0/bridge0 or something else can come along and open a PR and retest.
Below is the output on my system for "networksetup -listallhardwareports".
Notice the change will scan all starting with en which includes bluetooth, and although it's possible to ssh over bluetooth I didn't test that as it requires fiddling with the Pi which I cannot do now. It should be benign, just thought I'd mention it.
I'm still detecting 2 Pis when only 1 is on the network, but that happens without the change so it's likely an issue on my side with how I've setup the router to assign a fixed ip and so on, I'll dig a little more.

Hardware Port: Wi-Fi
Device: en0

Hardware Port: Bluetooth PAN
Device: en3

Hardware Port: Thunderbolt 1
Device: en1

Hardware Port: Thunderbolt 2
Device: en2

Hardware Port: Thunderbolt Bridge
Device: bridge0